### PR TITLE
Enable negative regex optional matching

### DIFF
--- a/configure/CONFIG_SITE
+++ b/configure/CONFIG_SITE
@@ -36,7 +36,7 @@ ifeq ($(OS_CLASS),WIN32)
 endif
 
 # Negative regexp matching: !pattern matches when pattern does not match
-#USE_NEG_REGEXP=YES
+USE_NEG_REGEXP=YES
 
 # Enable DENY FROM
 USE_DENY_FROM=YES


### PR DESCRIPTION
Enable negative regex matching as an option. This means an initial `!` on a line reverses the meaning of the match. This should be backward compatible as we do not start any lines/pvs with `!`  